### PR TITLE
fix: ensure all quality gates run with just all

### DIFF
--- a/justfile
+++ b/justfile
@@ -79,7 +79,9 @@ format:
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Lint all modules
-lint:
+lint: lint-other lint-android lint-ios lint-shared
+
+lint-other:
     ./gradlew lintKotlin detekt lint{{build_type}}
 
 # Lint Android module


### PR DESCRIPTION
## Summary

- Split `lint` target into separate dependencies so all lint checks run
- Previously `just all` would only run the root `lint` task, missing platform-specific lints

## Changes

The `lint` target now runs:
- `lint-other` - Root lintKotlin, detekt, and lint tasks
- `lint-android` - Android-specific lint checks
- `lint-ios` - SwiftLint for iOS code  
- `lint-shared` - Shared module lint checks