### PR TITLE
chore: add label to disable renovate auto-rebasing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
   ],
   "packageRules": [
     {
+      "matchLabels": [":no_entry_sign: DISABLE REBASING :no_entry_sign:"],
+      "rebaseWhen": "never"
+    },
+    {
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
## Summary
- Adds a new Renovate packageRule that disables auto-rebasing when the `:no_entry_sign: DISABLE REBASING :no_entry_sign:` label is applied to a PR
- Useful for preventing Renovate from rebasing PRs that need manual review or testing before updating