### PR TITLE
chore: add Renovate config validation to CI

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -32,3 +32,14 @@ jobs:
           cache: 'gradle'
       - name: Check dependency health
         run: just health
+
+  renovate-config:
+    name: Renovate Config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      - name: Validate Renovate config
+        run: just validate-renovate

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ build_type := "Debug"
 ios_simulator := env("IOS_SIMULATOR", "iPhone 17")
 
 # Default recipe - runs all quality gates
-all: clean health format lint test report assemble
+all: clean health validate-renovate format lint test report assemble
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Assemble & Bundle
@@ -154,6 +154,14 @@ report-ios: test-ios
 # Run dependency analysis health check
 health:
     ./gradlew projectHealth buildHealth
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Validate Renovate configuration
+validate-renovate:
+    npx --yes --package renovate -- renovate-config-validator
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CI Workflows

--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,8 @@
   "labels": [
     "dependencies :bricks:"
   ],
+  "stopUpdatingLabel": ":no_entry_sign: DISABLE REBASING :no_entry_sign:",
   "packageRules": [
-    {
-      "matchLabels": [":no_entry_sign: DISABLE REBASING :no_entry_sign:"],
-      "rebaseWhen": "never"
-    },
     {
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary
- Add CI job to validate Renovate configuration using `renovate-config-validator`
- Add `validate-renovate` recipe to justfile and include it in the `all` quality gates
- Simplify Renovate config by using `stopUpdatingLabel` instead of a package rule with `matchLabels`