### PR TITLE
refactor: replace button gradient with solid surface color

### DIFF
--- a/android/src/main/kotlin/com/hellocuriosity/drappula/ui/components/SoundButton.kt
+++ b/android/src/main/kotlin/com/hellocuriosity/drappula/ui/components/SoundButton.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.hellocuriosity.drappula.models.Sound
 import com.hellocuriosity.drappula.ui.screens.SoundPlayerTestTags
-import com.hellocuriosity.drappula.ui.theme.DrappulaTheme
 
 @Composable
 fun SoundButton(
@@ -33,7 +32,7 @@ fun SoundButton(
                 .testTag(SoundPlayerTestTags.soundButton(sound.id))
                 .shadow(4.dp, shape)
                 .clip(shape)
-                .background(DrappulaTheme.buttonGradient)
+                .background(MaterialTheme.colorScheme.surface)
                 .clickable(enabled = !isPlaying, onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         contentAlignment = Alignment.Center,

--- a/android/src/main/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaColorScheme.kt
+++ b/android/src/main/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaColorScheme.kt
@@ -33,8 +33,3 @@ fun ThemeColor.backgroundGradient(): Brush =
     Brush.verticalGradient(
         colors = listOf(gradientStart.toColor(), gradientEnd.toColor()),
     )
-
-fun ThemeColor.buttonGradient(): Brush =
-    Brush.verticalGradient(
-        colors = listOf(gradientStart.toColor(), gradientEnd.toColor()),
-    )

--- a/android/src/main/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaTheme.kt
+++ b/android/src/main/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaTheme.kt
@@ -20,7 +20,6 @@ fun DrappulaTheme(
     CompositionLocalProvider(
         LocalThemeColors provides themeColors,
         LocalBackgroundGradient provides themeColors.backgroundGradient(),
-        LocalButtonGradient provides themeColors.buttonGradient(),
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
@@ -47,14 +46,6 @@ val LocalBackgroundGradient =
     }
 
 /**
- * Local provider for button gradient.
- */
-val LocalButtonGradient =
-    staticCompositionLocalOf<Brush> {
-        error("No ButtonGradient provided")
-    }
-
-/**
  * Convenience object for accessing Drappula-specific theme values.
  */
 object DrappulaTheme {
@@ -65,8 +56,4 @@ object DrappulaTheme {
     val backgroundGradient: Brush
         @Composable
         get() = LocalBackgroundGradient.current
-
-    val buttonGradient: Brush
-        @Composable
-        get() = LocalButtonGradient.current
 }

--- a/android/src/test/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaColorSchemeTest.kt
+++ b/android/src/test/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaColorSchemeTest.kt
@@ -55,15 +55,4 @@ class DrappulaColorSchemeTest {
             gradient.hashCode(),
         )
     }
-
-    @Test
-    fun testButtonGradientContainsCorrectColors() {
-        val gradient = testThemeColor.buttonGradient()
-
-        // Verify gradient is created consistently
-        assertEquals(
-            testThemeColor.buttonGradient().hashCode(),
-            gradient.hashCode(),
-        )
-    }
 }

--- a/android/src/test/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaThemeTest.kt
+++ b/android/src/test/kotlin/com/hellocuriosity/drappula/ui/theme/DrappulaThemeTest.kt
@@ -52,19 +52,6 @@ class DrappulaThemeTest : CoroutinesComposeTest() {
     }
 
     @Test
-    fun testThemeProvidesButtonGradient() {
-        var buttonGradient: Brush? = null
-
-        composeTestRule.setContent {
-            DrappulaTheme(isDarkTheme = true) {
-                buttonGradient = DrappulaTheme.buttonGradient
-            }
-        }
-
-        assertEquals(SharedDraculaTheme.darkColors.buttonGradient(), buttonGradient)
-    }
-
-    @Test
     fun testMaterialThemeHasCorrectTypography() {
         var typography: androidx.compose.material3.Typography? = null
 

--- a/ios/drappula/Theme/DrappulaTheme.swift
+++ b/ios/drappula/Theme/DrappulaTheme.swift
@@ -101,7 +101,6 @@ private extension FontWeight {
 
 struct DrappulaGradients {
     let background: LinearGradient
-    let button: LinearGradient
 
     init(themeColors: ThemeColor) {
         let gradientColors = [
@@ -109,11 +108,6 @@ struct DrappulaGradients {
             Color(hex: themeColors.gradientEnd)
         ]
         self.background = LinearGradient(
-            colors: gradientColors,
-            startPoint: .top,
-            endPoint: .bottom
-        )
-        self.button = LinearGradient(
             colors: gradientColors,
             startPoint: .top,
             endPoint: .bottom

--- a/ios/drappula/ui/components/SoundButton.swift
+++ b/ios/drappula/ui/components/SoundButton.swift
@@ -15,7 +15,7 @@ struct SoundButton: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .frame(maxWidth: .infinity)
-                .background(theme.gradients.button)
+                .background(theme.colors.surface)
                 .foregroundColor(isPlaying ? theme.colors.onSurface.opacity(0.5) : theme.colors.onSurface)
                 .cornerRadius(10)
                 .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)

--- a/ios/drappulaTests/Theme/DrappulaThemeTests.swift
+++ b/ios/drappulaTests/Theme/DrappulaThemeTests.swift
@@ -32,7 +32,6 @@ struct DrappulaThemeTests {
         let theme = DrappulaThemeValues.light
         // Gradients should be initialized
         _ = theme.gradients.background
-        _ = theme.gradients.button
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace button gradient with solid surface color on both Android and iOS
- Remove unused `buttonGradient` theme properties and related code
- Update tests to reflect the changes