### PR TITLE
chore: update base color scheme

### DIFF
--- a/shared/src/commonMain/kotlin/com/hellocuriosity/drappula/themes/DraculaTheme.kt
+++ b/shared/src/commonMain/kotlin/com/hellocuriosity/drappula/themes/DraculaTheme.kt
@@ -1,8 +1,8 @@
 package com.hellocuriosity.drappula.themes
 
 object DraculaTheme : Theme {
-    private const val DEEP_PURPLE = "2d1b4e"
-    private const val BURGUNDY = "4a1c2e"
+    private const val DARK_BLACK = "0d0d0d"
+    private const val BLOOD_RED = "d32f2f"
     private const val BONE_WHITE = "f0e6d3"
 
     override val name: String = "Dracula"
@@ -11,27 +11,27 @@ object DraculaTheme : Theme {
 
     override val darkColors: ThemeColor =
         ThemeColor(
-            primary = DEEP_PURPLE,
-            secondary = BURGUNDY,
-            background = DEEP_PURPLE,
-            surface = BURGUNDY,
+            primary = DARK_BLACK,
+            secondary = BLOOD_RED,
+            background = DARK_BLACK,
+            surface = BLOOD_RED,
             onPrimary = BONE_WHITE,
             onBackground = BONE_WHITE,
             onSurface = BONE_WHITE,
-            gradientStart = DEEP_PURPLE,
-            gradientEnd = BURGUNDY,
+            gradientStart = DARK_BLACK,
+            gradientEnd = BLOOD_RED,
         )
 
     override val lightColors: ThemeColor =
         ThemeColor(
-            primary = DEEP_PURPLE,
-            secondary = BURGUNDY,
-            background = DEEP_PURPLE,
-            surface = BURGUNDY,
+            primary = DARK_BLACK,
+            secondary = BLOOD_RED,
+            background = DARK_BLACK,
+            surface = BLOOD_RED,
             onPrimary = BONE_WHITE,
             onBackground = BONE_WHITE,
             onSurface = BONE_WHITE,
-            gradientStart = DEEP_PURPLE,
-            gradientEnd = BURGUNDY,
+            gradientStart = DARK_BLACK,
+            gradientEnd = BLOOD_RED,
         )
 }

--- a/shared/src/commonTest/kotlin/com/hellocuriosity/drappula/themes/DraculaThemeTest.kt
+++ b/shared/src/commonTest/kotlin/com/hellocuriosity/drappula/themes/DraculaThemeTest.kt
@@ -7,27 +7,27 @@ class DraculaThemeTest : BaseThemeTest() {
     override val name: String = "Dracula"
     override val darkColors: ThemeColor =
         ThemeColor(
-            primary = "2d1b4e",
-            secondary = "4a1c2e",
-            background = "2d1b4e",
-            surface = "4a1c2e",
+            primary = "0d0d0d",
+            secondary = "d32f2f",
+            background = "0d0d0d",
+            surface = "d32f2f",
             onPrimary = "f0e6d3",
             onBackground = "f0e6d3",
             onSurface = "f0e6d3",
-            gradientStart = "2d1b4e",
-            gradientEnd = "4a1c2e",
+            gradientStart = "0d0d0d",
+            gradientEnd = "d32f2f",
         )
     override val lightColors: ThemeColor =
         ThemeColor(
-            primary = "2d1b4e",
-            secondary = "4a1c2e",
-            background = "2d1b4e",
-            surface = "4a1c2e",
+            primary = "0d0d0d",
+            secondary = "d32f2f",
+            background = "0d0d0d",
+            surface = "d32f2f",
             onPrimary = "f0e6d3",
             onBackground = "f0e6d3",
             onSurface = "f0e6d3",
-            gradientStart = "2d1b4e",
-            gradientEnd = "4a1c2e",
+            gradientStart = "0d0d0d",
+            gradientEnd = "d32f2f",
         )
     override val typography: Typography = Typography.Default
 


### PR DESCRIPTION
## Summary
- Update color scheme to match new branding with dark black background and blood red accents
- Replace deep purple/burgundy palette with dark black (#0d0d0d) and blood red (#d32f2f)