### PR TITLE
ci: optimize iOS test job by building simulator framework only

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -47,7 +47,7 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Build iOS Framework
-        run: just build-ios
+        run: just build-ios-simulator
       - name: Boot simulator
         run: |
           UDID=$(xcrun simctl list devices available -j | jq -r ".devices[] | .[] | select(.name == \"$IOS_SIMULATOR\") | .udid" | head -1)

--- a/justfile
+++ b/justfile
@@ -66,6 +66,10 @@ build-shared:
 build-ios:
     ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 :shared:linkDebugFrameworkIosArm64
 
+# Build iOS simulator framework only
+build-ios-simulator:
+    ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+
 # Build iOS native app
 build-ios-native:
     xcodebuild -project ios/drappula.xcodeproj -scheme drappula -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -configuration Debug build


### PR DESCRIPTION
## Summary

Closes #43

The iOS test job takes 30+ minutes despite having a tiny test suite (~9 files, ~195 lines). The bottleneck is the Gradle Kotlin/Native framework build, which compiles both the simulator (`IosSimulatorArm64`) and device (`IosArm64`) architectures. Since tests only run on the simulator, the device framework build is unnecessary.

This PR adds a `build-ios-simulator` recipe to the justfile and uses it in the iOS test workflow, skipping the `IosArm64` device framework compilation.

### Estimated CI Runtime Reduction

| Step | Before | After | Savings |
|------|--------|-------|---------|
| `linkDebugFrameworkIosSimulatorArm64` | ~10-15 min | ~10-15 min | — |
| `linkDebugFrameworkIosArm64` | ~10-15 min | skipped | ~10-15 min |
| **Total Gradle build** | **~20-30 min** | **~10-15 min** | **~50%** |

### Changes
- **`justfile`** — added `build-ios-simulator` recipe that only builds `IosSimulatorArm64`
- **`.github/workflows/ios.yml`** — updated the test job to use `build-ios-simulator`

The `build` job continues to use `build-ios` to compile both architectures, so there is no loss in coverage.