### PR TITLE
chore(ios): add encryption export compliance to Info.plist

### DIFF
--- a/ios/drappula/Info.plist
+++ b/ios/drappula/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
## Summary
- Add `ITSAppUsesNonExemptEncryption` key set to `false` in Info.plist
- Skips the encryption export compliance prompt on each App Store submission since the app doesn't use non-exempt encryption