### PR TITLE
chore: add KMP library plugin to AGP renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,8 @@
       "groupName": "Android Gradle Plugin",
       "matchPackageNames": [
         "/com.android.library/",
-        "/com.android.application/"
+        "/com.android.application/",
+        "/com.android.kotlin.multiplatform.library/"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add `com.android.kotlin.multiplatform.library` to the existing "Android Gradle Plugin" renovate group
- Prevents separate PRs for AGP-related plugin updates that should be grouped together