### PR TITLE
chore: ignore compat versions for kotlinx-datetime

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,12 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "org.jetbrains.kotlinx:kotlinx-datetime"
+      ],
+      "allowedVersions": "!/.*-compat$/"
+    },
+    {
       "groupName": "Android Test",
       "matchPackageNames": [
         "/androidx.test*/"


### PR DESCRIPTION
## Summary
- Add Renovate package rule to reject `kotlinx-datetime` versions ending in `-compat`
- Prevents Renovate from suggesting compatibility builds like `0.7.1-0.6.x-compat` when the project is already on the standard 0.7.x release line