### PR TITLE
chore: replace just with make as command runner

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -31,7 +29,7 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Linting
-        run: just lint-android
+        run: make lint-android
 
   test:
     name: Test & Report
@@ -39,8 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -48,7 +44,7 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Test
-        run: just report-android
+        run: make report-android
       - name: Report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
@@ -68,8 +64,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -80,6 +74,6 @@ jobs:
         run: |
           ./scripts/decrypt.sh keystore/drappula.jks.gpg keystore/drappula.jks ${{ secrets.KEY_STORE_GPG }}
       - name: Assemble
-        run: just flavor=Production build_type=Release assemble-android
+        run: make FLAVOR=Production BUILD_TYPE=Release assemble-android
       - name: Bundle
-        run: just flavor=Production build_type=Release bundle-android
+        run: make FLAVOR=Production BUILD_TYPE=Release bundle-android

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -31,7 +29,7 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Check dependency health
-        run: just health
+        run: make health
 
   renovate-config:
     name: Renovate Config
@@ -39,7 +37,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Validate Renovate config
-        run: just validate-renovate
+        run: make validate-renovate

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,12 +25,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: Linting
-        run: just lint-ios
+        run: make lint-ios
 
   test:
     name: Test & Report
@@ -38,8 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -52,11 +48,11 @@ jobs:
           xcrun simctl boot "$UDID" || true
           echo "SIMULATOR_UDID=$UDID" >> $GITHUB_ENV
       - name: Build iOS Framework
-        run: just build-ios-simulator
+        run: make build-ios-simulator
       - name: Wait for simulator
         run: xcrun simctl bootstatus "$SIMULATOR_UDID" -b
       - name: Test
-        run: just report-ios
+        run: make report-ios
       - name: Report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
@@ -70,8 +66,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -84,6 +78,6 @@ jobs:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
         run: scripts/create-secrets-plist.sh
       - name: Build iOS Framework
-        run: just build-ios
+        run: make build-ios
       - name: Build iOS App
-        run: just build-ios-native
+        run: make build-ios-native

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -39,7 +37,7 @@ jobs:
       - name: Set Version
         run: echo "VERSION=$(git tag --sort=committerdate | tail -1)" >> $GITHUB_ENV
       - name: Publishing
-        run: just flavor=Production build_type=Release clean bundle publish
+        run: make FLAVOR=Production BUILD_TYPE=Release clean bundle publish
 
   publish-ios:
     name: TestFlight Publish
@@ -52,8 +50,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
       - name: Set up JDK
@@ -105,13 +101,13 @@ jobs:
         run: scripts/create-secrets-plist.sh
 
       - name: Archive
-        run: just archive-ios
+        run: make archive-ios
 
       - name: Export IPA
-        run: just export-ios
+        run: make export-ios
 
       - name: Upload to TestFlight
-        run: just publish-ios
+        run: make publish-ios
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -31,7 +29,7 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Linting
-        run: just lint-shared
+        run: make lint-shared
 
   test:
     name: Test & Report
@@ -39,8 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -48,9 +44,9 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Shared Android
-        run: just test-shared-android
+        run: make test-shared-android
       - name: Shared iOS
-        run: just test-shared-ios report-shared
+        run: make test-shared-ios report-shared
       - name: Report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
@@ -64,8 +60,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -73,6 +67,6 @@ jobs:
           java-version: '19'
           cache: 'gradle'
       - name: Build Shared
-        run: just build-shared
+        run: make build-shared
       - name: Build iOS Framework
-        run: just build-ios
+        run: make build-ios

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,29 +24,24 @@ Drappula is a Kotlin Multiplatform (KMP) "Vampire Sound Machine" app targeting A
 ## Package Naming
 - Base package: `com.hellocuriosity.drappula`
 
-## Build Commands (using just)
-This project uses [just](https://github.com/casey/just) as a command runner.
+## Build Commands (using make)
+This project uses `make` as its command runner.
 
 ### Common Commands
-- `just all` - Run all quality gates (clean, format, lint, test, report, assemble)
-- `just build` - Build all platforms
-- `just format` - Format all Kotlin code
-- `just lint` - Run all linters (Kotlinter, Detekt, Android Lint)
-- `just test` - Run all tests
-- `just report` - Generate code coverage reports
-- `just clean` - Clean build outputs
+- `make all` - Run all quality gates (clean, format, lint, test, report, assemble)
+- `make build` - Build all platforms
+- `make format` - Format all Kotlin code
+- `make lint` - Run all linters (Kotlinter, Detekt, Android Lint)
+- `make test` - Run all tests
+- `make report` - Generate code coverage reports
+- `make clean` - Clean build outputs
 
 ### Platform-Specific
-- `just build-android` - Build Android app
-- `just build-ios` - Build iOS framework
-- `just test-android` - Run Android tests
-- `just test-shared` - Run shared module tests
-- `just ci` - Run full CI pipeline locally
-
-### Direct Gradle (if just not available)
-- `./gradlew build` - Build all modules
-- `./gradlew formatKotlin` - Auto-format Kotlin code
-- `./gradlew detekt lintKotlin` - Run static analysis
+- `make build-android` - Build Android app
+- `make build-ios` - Build iOS framework
+- `make test-android` - Run Android tests
+- `make test-shared` - Run shared module tests
+- `make ci` - Run full CI pipeline locally
 
 ---
 
@@ -72,8 +67,8 @@ actual fun getPlatformName(): String = "iOS"
 Place shared dependencies in `commonMain.dependencies` block in `shared/build.gradle.kts`.
 
 ## Code Quality
-- Run `just format` before committing
-- Run `just lint` to check for code smells (runs Kotlinter, Detekt, and Android Lint)
+- Run `make format` before committing
+- Run `make lint` to check for code smells (runs Kotlinter, Detekt, and Android Lint)
 - Follow Kotlinter formatting rules
 - Follow Detekt rules defined in `detekt/detekt.yml`
 - Use JVM target 19 for Android

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
-build_type := "Debug"
-flavor := "Staging"
+# Variables - use ?= so environment variables and command-line overrides take precedence
+BUILD_TYPE ?= Debug
+FLAVOR ?= Staging
 
 # iOS simulator for testing - override with IOS_SIMULATOR env var
 # Use 'xcrun simctl list devices available' to see options
-ios_simulator := env("IOS_SIMULATOR", "iPhone 17")
+IOS_SIMULATOR ?= iPhone 17
 
 # iOS signing - set via environment variables or .env file
-team_id := env("TEAM_ID", "")
-provisioning_profile_name := env("PROVISIONING_PROFILE_NAME", "")
-marketing_version := env("MARKETING_VERSION", "1.0")
-build_number := env("BUILD_NUMBER", "1")
+TEAM_ID ?=
+PROVISIONING_PROFILE_NAME ?=
+MARKETING_VERSION ?= 1.0
+BUILD_NUMBER ?= 1
 
-# Default recipe - runs all quality gates
+# Default target - runs all quality gates
 all: clean validate-renovate format lint test report assemble
+.PHONY: all
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Assets
@@ -20,18 +22,8 @@ all: clean validate-renovate format lint test report assemble
 
 # Sync audio symlinks for Android assets
 asset-sync:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    ASSETS_AUDIO="android/src/main/assets/audio"
-    mkdir -p "$ASSETS_AUDIO"
-    for dir in audio/*/; do
-        name=$(basename "$dir")
-        link="$ASSETS_AUDIO/$name"
-        if [ ! -L "$link" ]; then
-            ln -s "../../../../../audio/$name" "$link"
-            echo "Created symlink: $link"
-        fi
-    done
+	./scripts/asset-sync.sh
+.PHONY: asset-sync
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Assemble & Bundle
@@ -39,19 +31,23 @@ asset-sync:
 
 # Assemble all modules
 assemble:
-    ./gradlew assemble{{flavor}}{{build_type}}
+	./gradlew assemble$(FLAVOR)$(BUILD_TYPE)
+.PHONY: assemble
 
 # Assemble Android app
 assemble-android:
-    ./gradlew :android:assemble{{flavor}}{{build_type}}
+	./gradlew :android:assemble$(FLAVOR)$(BUILD_TYPE)
+.PHONY: assemble-android
 
 # Bundle all modules
 bundle:
-    ./gradlew bundle{{flavor}}{{build_type}}
+	./gradlew bundle$(FLAVOR)$(BUILD_TYPE)
+.PHONY: bundle
 
 # Bundle Android app
 bundle-android:
-    ./gradlew :android:bundle{{flavor}}{{build_type}}
+	./gradlew :android:bundle$(FLAVOR)$(BUILD_TYPE)
+.PHONY: bundle-android
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Build
@@ -59,36 +55,44 @@ bundle-android:
 
 # Build all platforms
 build: build-android build-ios
+.PHONY: build
 
 # Build Android app
 build-android:
-    ./gradlew :android:build{{flavor}}{{build_type}}
+	./gradlew :android:build$(FLAVOR)$(BUILD_TYPE)
+.PHONY: build-android
 
 # Build shared module
 build-shared:
-    ./gradlew :shared:build
+	./gradlew :shared:build
+.PHONY: build-shared
 
 # Build iOS framework
 build-ios:
-    ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 :shared:linkDebugFrameworkIosArm64
+	./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 :shared:linkDebugFrameworkIosArm64
+.PHONY: build-ios
 
 # Build iOS simulator framework only
 build-ios-simulator:
-    ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+	./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+.PHONY: build-ios-simulator
 
 # Build iOS native app
 build-ios-native:
-    xcodebuild -project ios/drappula.xcodeproj -scheme drappula -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -configuration Debug build
+	xcodebuild -project ios/drappula.xcodeproj -scheme drappula -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -configuration Debug build
+.PHONY: build-ios-native
 
 # Archive iOS app for distribution (requires TEAM_ID, PROVISIONING_PROFILE_NAME, MARKETING_VERSION, BUILD_NUMBER env vars)
 archive-ios:
-    ./gradlew :shared:linkReleaseFrameworkIosArm64
-    xcodebuild -project ios/drappula.xcodeproj -scheme drappula -configuration Release -sdk iphoneos -destination 'generic/platform=iOS' -archivePath build/ios/drappula.xcarchive MARKETING_VERSION={{marketing_version}} CURRENT_PROJECT_VERSION={{build_number}} DEVELOPMENT_TEAM={{team_id}} PROVISIONING_PROFILE_SPECIFIER="{{provisioning_profile_name}}" archive
+	./gradlew :shared:linkReleaseFrameworkIosArm64
+	xcodebuild -project ios/drappula.xcodeproj -scheme drappula -configuration Release -sdk iphoneos -destination 'generic/platform=iOS' -archivePath build/ios/drappula.xcarchive MARKETING_VERSION=$(MARKETING_VERSION) CURRENT_PROJECT_VERSION=$(BUILD_NUMBER) DEVELOPMENT_TEAM=$(TEAM_ID) PROVISIONING_PROFILE_SPECIFIER="$(PROVISIONING_PROFILE_NAME)" archive
+.PHONY: archive-ios
 
 # Export iOS archive to IPA (requires TEAM_ID and PROVISIONING_PROFILE_NAME env vars)
 export-ios:
-    ./scripts/generate-export-options.sh
-    xcodebuild -exportArchive -archivePath build/ios/drappula.xcarchive -exportPath build/ios/output -exportOptionsPlist build/ios/ExportOptions.plist
+	./scripts/generate-export-options.sh
+	xcodebuild -exportArchive -archivePath build/ios/drappula.xcarchive -exportPath build/ios/output -exportOptionsPlist build/ios/ExportOptions.plist
+.PHONY: export-ios
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Clean
@@ -96,14 +100,17 @@ export-ios:
 
 # Clean Gradle build
 clean:
-    ./gradlew clean
+	./gradlew clean
+.PHONY: clean
 
 # Clean iOS build
 clean-ios:
-    xcodebuild -project ios/drappula.xcodeproj -scheme drappula clean
+	xcodebuild -project ios/drappula.xcodeproj -scheme drappula clean
+.PHONY: clean-ios
 
 # Clean all builds
 clean-all: clean clean-ios
+.PHONY: clean-all
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Format
@@ -111,7 +118,8 @@ clean-all: clean clean-ios
 
 # Format all Kotlin code
 format:
-    ./gradlew formatKotlin
+	./gradlew formatKotlin
+.PHONY: format
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Lint
@@ -119,21 +127,26 @@ format:
 
 # Lint all modules
 lint: lint-other lint-android lint-ios lint-shared
+.PHONY: lint
 
 lint-other:
-    ./gradlew lintKotlin detekt lint{{flavor}}{{build_type}}
+	./gradlew lintKotlin detekt lint$(FLAVOR)$(BUILD_TYPE)
+.PHONY: lint-other
 
 # Lint Android module
 lint-android:
-    ./gradlew :android:lintKotlin :android:detekt :android:lint{{flavor}}{{build_type}}
+	./gradlew :android:lintKotlin :android:detekt :android:lint$(FLAVOR)$(BUILD_TYPE)
+.PHONY: lint-android
 
 # Lint shared module (no Android Lint with com.android.kotlin.multiplatform.library)
 lint-shared:
-    ./gradlew :shared:lintKotlin :shared:detekt
+	./gradlew :shared:lintKotlin :shared:detekt
+.PHONY: lint-shared
 
 # Lint iOS code with SwiftLint
 lint-ios:
-    swiftlint lint ios/drappula --strict
+	swiftlint lint ios/drappula --strict
+.PHONY: lint-ios
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test
@@ -141,27 +154,33 @@ lint-ios:
 
 # Run all tests
 test: test-android test-shared test-ios
+.PHONY: test
 
 # Run Android unit tests
 test-android:
-    ./gradlew :android:test{{flavor}}{{build_type}}UnitTest
+	./gradlew :android:test$(FLAVOR)$(BUILD_TYPE)UnitTest
+.PHONY: test-android
 
 # Run all shared module tests
 test-shared: test-shared-android test-shared-ios
+.PHONY: test-shared
 
 # Run shared module tests on Android (host test)
 test-shared-android:
-    ./gradlew :shared:testAndroidHostTest
+	./gradlew :shared:testAndroidHostTest
+.PHONY: test-shared-android
 
 # Run shared module tests on iOS
 test-shared-ios:
-    ./gradlew :shared:cleanIosX64Test :shared:iosX64Test
+	./gradlew :shared:cleanIosX64Test :shared:iosX64Test
+.PHONY: test-shared-ios
 
 # Run iOS native tests
 test-ios:
-    rm -rf build/ios/results.xcresult
-    mkdir -p build/ios
-    xcodebuild -project ios/drappula.xcodeproj -scheme drappula -sdk iphonesimulator -destination 'platform=iOS Simulator,name={{ios_simulator}}' -enableCodeCoverage YES -resultBundlePath build/ios/results.xcresult test
+	rm -rf build/ios/results.xcresult
+	mkdir -p build/ios
+	xcodebuild -project ios/drappula.xcodeproj -scheme drappula -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -enableCodeCoverage YES -resultBundlePath build/ios/results.xcresult test
+.PHONY: test-ios
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Report (Code Coverage)
@@ -169,22 +188,26 @@ test-ios:
 
 # Generate all coverage reports
 report:
-    ./gradlew koverHtmlReport koverXmlReport
+	./gradlew koverHtmlReport koverXmlReport
+.PHONY: report
 
 # Generate Android coverage report
 report-android:
-    ./gradlew :android:koverHtmlReport :android:koverXmlReport
+	./gradlew :android:koverHtmlReport :android:koverXmlReport
+.PHONY: report-android
 
 # Generate shared module coverage report
 # Kover disabled for shared module until it supports com.android.kotlin.multiplatform.library
 # See: https://github.com/hopeman15/drappula/issues/11
 report-shared:
-    @echo "Kover is disabled for shared module - see issue #11"
+	@echo "Kover is disabled for shared module - see issue #11"
+.PHONY: report-shared
 
 # Generate iOS coverage report (runs tests first)
 report-ios: test-ios
-    xcrun xccov view --report --json build/ios/results.xcresult > build/ios/coverage.json
-    xcrun xccov view --report build/ios/results.xcresult
+	xcrun xccov view --report --json build/ios/results.xcresult > build/ios/coverage.json
+	xcrun xccov view --report build/ios/results.xcresult
+.PHONY: report-ios
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Dependency Analysis (Health Checks)
@@ -192,7 +215,8 @@ report-ios: test-ios
 
 # Run dependency analysis health check
 health:
-    ./gradlew projectHealth buildHealth
+	./gradlew projectHealth buildHealth
+.PHONY: health
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Validation
@@ -200,23 +224,8 @@ health:
 
 # Validate Renovate configuration
 validate-renovate:
-    npx --yes --package renovate -- renovate-config-validator
-
-# ─────────────────────────────────────────────────────────────────────────────
-# CI Workflows
-# ─────────────────────────────────────────────────────────────────────────────
-
-# Run Android CI workflow locally
-ci-android: lint-android test-android report-android build-android
-
-# Run shared module CI workflow locally
-ci-shared: lint-shared test-shared report-shared build-shared
-
-# Run iOS CI workflow locally
-ci-ios: lint-ios report-ios build-ios build-ios-native
-
-# Run all CI workflows
-ci: ci-android ci-shared ci-ios
+	npx --yes --package renovate -- renovate-config-validator
+.PHONY: validate-renovate
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Publishing & Release
@@ -224,12 +233,15 @@ ci: ci-android ci-shared ci-ios
 
 # Publish to Play Store (requires KEY_STORE_GPG and PLAY_PUBLISH_PASSWORD env vars)
 publish:
-    ./scripts/publish.sh {{flavor}} Release ${KEY_STORE_GPG} ${PLAY_PUBLISH_PASSWORD}
+	./scripts/publish.sh $(FLAVOR) Release $${KEY_STORE_GPG} $${PLAY_PUBLISH_PASSWORD}
+.PHONY: publish
 
 # Publish iOS app to TestFlight (requires ASC_KEY_ID, ASC_ISSUER_ID, and API key file)
 publish-ios:
-    ./scripts/publish-ios.sh
+	./scripts/publish-ios.sh
+.PHONY: publish-ios
 
 # Interactive local signing
 signing:
-    ./scripts/signing.sh {{flavor}} Release
+	./scripts/signing.sh $(FLAVOR) Release
+.PHONY: signing

--- a/scripts/asset-sync.sh
+++ b/scripts/asset-sync.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ASSETS_AUDIO="android/src/main/assets/audio"
+mkdir -p "$ASSETS_AUDIO"
+
+for dir in audio/*/; do
+    name=$(basename "$dir")
+    link="$ASSETS_AUDIO/$name"
+    if [ ! -L "$link" ]; then
+        ln -s "../../../../../audio/$name" "$link"
+        echo "Created symlink: $link"
+    fi
+done


### PR DESCRIPTION
## Summary

- Replace `just` (justfile) with `make` (Makefile) as the project's command runner
- Extract the `asset-sync` shebang block from the justfile into `scripts/asset-sync.sh`
- Remove all `setup-just` steps from 5 CI workflows and replace `just` commands with `make`
- Update `CLAUDE.md` to document `make` commands
- Delete the justfile