### PR TITLE
chore: update pr command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -8,7 +8,20 @@ You are tasked with creating a pull request for the changes on the current branc
    - Run `git log` and `git diff` against the base branch to understand all commits
    - Review the full scope of changes, not just the latest commit
 
-2. **Draft the PR:**
+2. **Check for a PR template:**
+   - Look for a pull request template in the following locations (in order):
+     - `.github/PULL_REQUEST_TEMPLATE.md`
+     - `.github/pull_request_template.md`
+     - `PULL_REQUEST_TEMPLATE.md`
+     - `pull_request_template.md`
+     - `.github/PULL_REQUEST_TEMPLATE/` (use the default template in this directory)
+   - If a template is found, use it as the structure for the PR body
+   - Fill in each section of the template based on the changes
+   - Remove HTML comments (e.g., `<!-- ... -->`) and replace them with actual content
+   - Check off checklist items that are clearly addressed by the code changes
+   - Leave unchecked any items that are not clearly satisfied
+
+3. **Draft the PR:**
    - Use conventional commits style for the title: `type: description`
      - `feat:` new feature
      - `fix:` bug fix
@@ -17,10 +30,11 @@ You are tasked with creating a pull request for the changes on the current branc
      - `refactor:` code refactoring
      - `test:` adding or updating tests
      - `ci:` CI/CD changes
-   - Keep the summary concise with bullet points
-   - Do NOT include a "Test plan" section
+   - If a PR template was found, populate its sections with relevant content
+   - If no template was found, keep the summary concise with bullet points
+   - Do NOT include a "Test plan" section unless the template has one
 
-3. **Create the PR:**
+4. **Create the PR:**
    - Push the branch if needed
    - Use `gh pr create` to open the pull request
 


### PR DESCRIPTION
## Description

Update the `/pr` command to detect and use pull request templates when creating PRs. The command now searches standard GitHub template locations, populates template sections with relevant content, and intelligently checks off satisfied checklist items.

## UI

N/A — no UI changes.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [-] Tests have been written
- [-] Screenshots added (where applicable)
- [x] Appropriate labels have been applied