### PR TITLE
fix: align iOS settings title padding with sound player screen

### DIFF
--- a/ios/drappula/ui/screens/SettingsView.swift
+++ b/ios/drappula/ui/screens/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
                     .ignoresSafeArea()
 
                 ScrollView {
-                    VStack(spacing: 0) {
+                    VStack {
                         Text("Settings")
                             .font(theme.typography.display)
                             .fontWeight(.bold)
@@ -53,6 +53,7 @@ struct SettingsView: View {
                         Divider()
                             .background(theme.colors.onBackground.opacity(0.2))
                     }
+                    .padding()
                 }
             }
             .navigationBarHidden(true)


### PR DESCRIPTION
## Description

Align the iOS Settings screen padding with the Sound Player screen by removing explicit `spacing: 0` from the VStack and adding `.padding()` to the content.

## UI

| Before | After |
|--------|------|
|<img width="1170" height="2532" alt="before" src="https://github.com/user-attachments/assets/55841073-0412-4fad-8995-17a40f1c389a" />|<img width="1170" height="2532" alt="after" src="https://github.com/user-attachments/assets/17db8405-7c5f-4a24-a505-a95bf1de2ea4" />|

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [-] Tests have been written
- [x] Screenshots added (where applicable)
- [x] Appropriate labels have been applied