### PR TITLE
fix(test): remove unnecessary nullability from SlackRepositoryTest

### DIFF
--- a/shared/src/commonTest/kotlin/com/hellocuriosity/drappula/data/repository/SlackRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/hellocuriosity/drappula/data/repository/SlackRepositoryTest.kt
@@ -54,7 +54,7 @@ class SlackRepositoryTest {
                         ),
                     feedbackConverter = FeedbackConverter(channelId = "test-channel", platform = "test"),
                 ) {
-                    override suspend fun postFeedback(value: Feedback): Feedback? {
+                    override suspend fun postFeedback(value: Feedback): Feedback {
                         capturedFeedback = value
                         return value
                     }
@@ -67,6 +67,6 @@ class SlackRepositoryTest {
 
             assertNotNull(result)
             assertNotNull(capturedFeedback)
-            assertEquals(fixedInstant, capturedFeedback?.created)
+            assertEquals(fixedInstant, capturedFeedback.created)
         }
 }


### PR DESCRIPTION
## Summary
- Remove unnecessary nullable return type from `postFeedback` override in test
- Use non-null access on `capturedFeedback` since it's guaranteed to be set after `assertNotNull`