### PR TITLE
chore: set staging as default product flavor

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -77,13 +77,14 @@ android {
 
     flavorDimensions.addAll(listOf("all"))
     productFlavors {
-        create("production") {
-            dimension = "all"
-        }
         create("staging") {
+            isDefault = true
             dimension = "all"
             versionNameSuffix = "-staging"
             applicationIdSuffix = ".staging"
+        }
+        create("production") {
+            dimension = "all"
         }
     }
 


### PR DESCRIPTION
## Summary
- Set staging as the default product flavor with `isDefault = true`
- Reorder product flavors so staging is defined first