### PR TITLE
fix: re-enable Kover for shared module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,10 +198,8 @@ report-android:
 .PHONY: report-android
 
 # Generate shared module coverage report
-# Kover disabled for shared module until it supports com.android.kotlin.multiplatform.library
-# See: https://github.com/hopeman15/drappula/issues/11
 report-shared:
-	@echo "Kover is disabled for shared module - see issue #11"
+	./gradlew :shared:koverHtmlReport :shared:koverXmlReport
 .PHONY: report-shared
 
 # Generate iOS coverage report (runs tests first)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,7 @@ plugins {
 allprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jmailen.kotlinter")
-    // Kover doesn't support com.android.kotlin.multiplatform.library plugin yet
-    // Upstream: https://github.com/Kotlin/kotlinx-kover/issues/772
-    // Tracking: https://github.com/hopeman15/drappula/issues/11
-    if (name != "shared") {
-        apply(plugin = "org.jetbrains.kotlinx.kover")
-    }
+    apply(plugin = "org.jetbrains.kotlinx.kover")
 
     detekt {
         config.setFrom("$rootDir/detekt/detekt.yml")
@@ -64,7 +59,5 @@ dependencyAnalysis {
 
 dependencies {
     kover(project(":android"))
-    // TODO: Re-enable once Kover supports com.android.kotlin.multiplatform.library
-    // https://github.com/hopeman15/drappula/issues/11
-    // kover(project(":shared"))
+    kover(project(":shared"))
 }


### PR DESCRIPTION
## Summary

- Re-enables Kover code coverage for the `shared` KMP module now that it supports `com.android.kotlin.multiplatform.library`
- Removes the conditional plugin application that excluded the shared module
- Adds `:shared` to the root-level Kover aggregation dependencies
- Restores `report-shared` make target to generate HTML and XML coverage reports

Closes #11